### PR TITLE
fix typo in about box

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -53,7 +53,7 @@ msgid "Architecture: "
 msgstr ""
 
 msgctxt "#609"
-msgid "Open Embedded Linux Entertainment Center (OpenELEC) is a minimal Linux distribution purpose built for XBMC media center. OpenELEC is designed to boot fast with an installation process simple enough for anyone to convert a bare HTPC into a fully configuredd media machine in under 15 minutes."
+msgid "Open Embedded Linux Entertainment Center (OpenELEC) is a minimal Linux distribution purpose built for XBMC media center. OpenELEC is designed to boot fast with an installation process simple enough for anyone to convert a bare HTPC into a fully configured media machine in under 15 minutes."
 msgstr ""
 
 msgctxt "#610"


### PR DESCRIPTION
This fixes a typo in settings -> openelec -> about.
