### PR TITLE
Add support for waitForAbort() when method is avilable in Kodi

### DIFF
--- a/src/service.py
+++ b/src/service.py
@@ -114,8 +114,7 @@ oe.start_service()
 monitor = service_thread(oe.__oe__)
 monitor.start()
 
-while not xbmc.abortRequested:
-    xbmc.sleep(100)
+xbmcm.waitForAbort()
 
 if hasattr(oe, 'winOeMain'):
     if oe.winOeMain.visible == True:


### PR DESCRIPTION
`waitForAbort()` has been added in Kodi Helix. This change could even be backported to OE 5.x.

This change has been present in my RPi builds for several months now. The version check isn't strictly necessary, and can be removed along with everything in the `else` - let me know and I'll squash an update.